### PR TITLE
Cannot swap king functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ When person wins, if signed in, add one to their count with their userId.
 - Give options to choose the card they want to cut to? A button from 1 to 52 - len(players) for them to choose their card? Think of ways to do this. May just be creating 52 - players of card displays on the screen and they choose one, it then finds which one of the array it was, gets the array number and send that to the serve and they get the relevant card.
 Or add a randomiser before pulling off the card.
 
+> Testing notes
+- Look at setting the card object in the card class. Add a set method but don't use it in the main code. Just have the setting for instigating very specific scenarios.
 
 > Bugs
 - Clear at the moment.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,26 @@ When host quits, boot everyone
 When person wins, if signed in, add one to their count with their userId.
 
 > Functionality left to implement
-- Cannot swap a king.
+- Cannot swap a king. Have it where if they click trade, it denies it and gives them a popup. Also reveals said king to everyone.
+- If player clicks trade:
+  - / Skip trade 
+  - / Emit popup trigger just to player
+  - Display popup saying next player has a king.
+  - Reveal king next to player to everyone.
+
+- If a person has a king:
+  - Skip to next person before giving them options.
+
+- Give person with king option to display their card.
+
+---
+- Have it so a player, if they have a king can flip it and display it on the side of the game. Have it where it's their place in the playerList times i for its position. Once it's flipped, the next person doesn't have the trade option anymore.
 - Dealer shouldn't see their card.
 - Can swap a king if it's the dealers card because they haven't see it.
   So if not equal to dealer then don't swap and give a message back, or don't give option.
   Check next card in deck and if king then skip options and update current player.
 - Add gameType to Player model and adjust getPlayerList and relevant methods. Needed for adding shed game. 
 
-- Awarding score for winner if they are signed in.
 - Saying you're the dealer when you are.
 - Selection for how many lives you want
 - Displaying whos go it is on player list.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ When person wins, if signed in, add one to their count with their userId.
 - If player clicks trade:
   - / Skip trade 
   - / Emit popup trigger just to player
-  - Display popup saying next playerList has a king.
+  - / Display popup saying next playerList has a king.
   - Reveal king next to player to everyone.
 
 - If a person has a king:
- - skip player before giving actions, unless they are the dealer, in which case end the round.
+ - /skip player before giving actions, unless they are the dealer, in which case end the round.
 
 - Give person with king option to display their card. If it has been revealed already, get rid of button to reveal. If it's revealed by trade, create king revealed array for storing true or false selector for all players on whether their king has been revealed already and if it has then ignore the matching reveal code.
+  - Could store the player position in the queue somewhere to keep where to place their card if they have a king and reveal. If a elegant solution isn't found for doing the deletion of the king image or skipping code if the king is already revealed then just layed them on top of each other and delete all at the end of the round. Just wipe the array.
 
 ---
 - Have it so a player, if they have a king can flip it and display it on the side of the game. Have it where it's their place in the playerList times i for its position. Once it's flipped, the next person doesn't have the trade option anymore.

--- a/README.md
+++ b/README.md
@@ -44,20 +44,6 @@ When host quits, boot everyone
 When person wins, if signed in, add one to their count with their userId.
 
 > Functionality left to implement
-- Cannot swap a king. Have it where if they click trade, it denies it and gives them a popup. Also reveals said king to everyone.
-- If player clicks trade:
-  - / Skip trade 
-  - / Emit popup trigger just to player
-  - / Display popup saying next playerList has a king.
-  - Reveal king next to player to everyone.
-
-- If a person has a king:
- - /skip player before giving actions, unless they are the dealer, in which case end the round.
-
-- Give person with king option to display their card. If it has been revealed already, get rid of button to reveal. If it's revealed by trade, create king revealed array for storing true or false selector for all players on whether their king has been revealed already and if it has then ignore the matching reveal code.
-  - Could store the player position in the queue somewhere to keep where to place their card if they have a king and reveal. If a elegant solution isn't found for doing the deletion of the king image or skipping code if the king is already revealed then just layed them on top of each other and delete all at the end of the round. Just wipe the array.
-
----
 - Have it so a player, if they have a king can flip it and display it on the side of the game. Have it where it's their place in the playerList times i for its position. Once it's flipped, the next person doesn't have the trade option anymore.
 - Dealer shouldn't see their card.
 - Can swap a king if it's the dealers card because they haven't see it.
@@ -65,6 +51,7 @@ When person wins, if signed in, add one to their count with their userId.
   Check next card in deck and if king then skip options and update current player.
 - Add gameType to Player model and adjust getPlayerList and relevant methods. Needed for adding shed game. 
 
+- When the host quits a game, have a popup and on clicking 'ok' then redirect.
 - Saying you're the dealer when you are.
 - Selection for how many lives you want
 - Displaying whos go it is on player list.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ When person wins, if signed in, add one to their count with their userId.
 - If player clicks trade:
   - / Skip trade 
   - / Emit popup trigger just to player
-  - Display popup saying next player has a king.
+  - Display popup saying next playerList has a king.
   - Reveal king next to player to everyone.
 
 - If a person has a king:
-  - Skip to next person before giving them options.
+ - skip player before giving actions, unless they are the dealer, in which case end the round.
 
-- Give person with king option to display their card.
+- Give person with king option to display their card. If it has been revealed already, get rid of button to reveal. If it's revealed by trade, create king revealed array for storing true or false selector for all players on whether their king has been revealed already and if it has then ignore the matching reveal code.
 
 ---
 - Have it so a player, if they have a king can flip it and display it on the side of the game. Have it where it's their place in the playerList times i for its position. Once it's flipped, the next person doesn't have the trade option anymore.

--- a/application/classes/chase_the_ace/action.py
+++ b/application/classes/chase_the_ace/action.py
@@ -111,7 +111,7 @@ class Action:
                 nextPlayerCard = nextPlayer.card
 
                 if 'king' in nextPlayerCard:
-                    emit('Next player has a king')
+                    emit('next player has a king')
                     # Add reveal king emit here for entire room. send position in list ?
                 else:
                     player.card = nextPlayerCard

--- a/application/classes/chase_the_ace/action.py
+++ b/application/classes/chase_the_ace/action.py
@@ -3,6 +3,7 @@ import random
 from ... import db
 from .databaseUtils import DatabaseUtils
 from ast import literal_eval
+from ... import socketio, send, emit
 
 dbUtils = DatabaseUtils()
 
@@ -10,7 +11,6 @@ dbUtils = DatabaseUtils()
 class Action:
 
     def dealCards(roomId):
-
         # Makes copy of cards deck to deal to the players (always using a new full deck.)
         currentDeck = Card.cards[:]
 
@@ -63,7 +63,6 @@ class Action:
         db.session.commit()
 
     def updateCurrentDealer(roomId):
-
         # Retrieving the list of players and the room data.
         playerList = dbUtils.getPlayerList(roomId)
         room = dbUtils.getRoom(roomId)
@@ -87,7 +86,6 @@ class Action:
         db.session.commit()
 
     def tradeCards(roomId):
-
         # Retrieving the list of players and the room data.
         playerList = dbUtils.getPlayerList(roomId)
         room = dbUtils.getRoom(roomId)
@@ -112,15 +110,19 @@ class Action:
                 playerCard = player.card
                 nextPlayerCard = nextPlayer.card
 
-                player.card = nextPlayerCard
-                nextPlayer.card = playerCard
+                if 'king' in nextPlayerCard:
+                    emit('Next player has a king')
+                    Action.updateCurrentPlayer(roomId, previousPlayer='player')
+                    # Add reveal king emit here for entire room. send position in list ?
+                else:
+                    player.card = nextPlayerCard
+                    nextPlayer.card = playerCard
                 break
 
         # Commit changes
         db.session.commit()
 
     def cutTheDeck(roomId):
-
         # Retrieving the list of players and the room data.
         playerList = dbUtils.getPlayerList(roomId)
         room = dbUtils.getRoom(roomId)
@@ -140,7 +142,6 @@ class Action:
         db.session.commit()
 
     def calculateRoundWinner(roomId):
-
         # Get the list of players
         playerList = dbUtils.getPlayerList(roomId)
 

--- a/application/classes/chase_the_ace/action.py
+++ b/application/classes/chase_the_ace/action.py
@@ -94,7 +94,7 @@ class Action:
             # Getting the current player.
             player = playerList[i]
 
-            # Getting the generated id of the player next to the dealer.
+            # Getting the generated id of the player next to the player.
             if player.generatedPlayerId == room.currentPlayerId:
 
                 # If the current player is at the edge of the array, then set it back to
@@ -112,7 +112,6 @@ class Action:
 
                 if 'king' in nextPlayerCard:
                     emit('Next player has a king')
-                    Action.updateCurrentPlayer(roomId, previousPlayer='player')
                     # Add reveal king emit here for entire room. send position in list ?
                 else:
                     player.card = nextPlayerCard

--- a/application/classes/chase_the_ace/databaseUtils.py
+++ b/application/classes/chase_the_ace/databaseUtils.py
@@ -23,6 +23,9 @@ class DatabaseUtils():
     def getDealerId(self, roomId):
         return self.getRoom(roomId).dealerPlayerId
 
+    def getPlayerCard(self, roomId, playerId):
+        return self.getSpecificPlayer(roomId, playerId).card
+
     # Make more generic later when new games are added.
     def addWinToUser(self, winningPlayerId):
         userId = models.Player.query.filter_by(generatedPlayerId=winningPlayerId).first().userId

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -129,7 +129,7 @@ def startGame():
         # Setting the lives of the players and their out of game statuses.
         playerList = dbUtils.getPlayerList(roomId)
         for i in range(len(playerList)):
-            playerList[i].lives = 2
+            playerList[i].lives = 5
             playerList[i].outOfGame = False
         db.session.commit()
 
@@ -159,7 +159,19 @@ def startGame():
 
     # Giving the current player the choice.
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-    emit('give player choice', currentPlayerId, room = roomId)
+    dealerPlayerId = dbUtils.getDealerId(roomId)
+    currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    while 'king' in currentPlayerCard:
+        if currentPlayerId == dealerPlayerId:
+            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+            endRound(roomId)
+            break
+        else:
+            Action.updateCurrentPlayer(roomId, previousPlayer='player')
+            currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+        emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('stick card')
 def stickCard():
@@ -183,10 +195,26 @@ def stickCard():
     else:
         # increments the player as their choice doesn't make a change.
         Action.updateCurrentPlayer(roomId, previousPlayer='player')
-        currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+        # currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+        #
+        # # Giving the new current player the choice.
+        # emit('give player choice', currentPlayerId, room=roomId)
 
-        # Giving the new current player the choice.
-        emit('give player choice', currentPlayerId, room=roomId)
+        # Giving the current player the choice.
+        currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+        dealerPlayerId = dbUtils.getDealerId(roomId)
+        currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+        while 'king' in currentPlayerCard:
+            if currentPlayerId == dealerPlayerId:
+                currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+                endRound(roomId)
+                break
+            else:
+                Action.updateCurrentPlayer(roomId, previousPlayer='player')
+                currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+                currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+        if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+            emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('trade card')
 def tradeCard():
@@ -203,15 +231,27 @@ def tradeCard():
     playersJson = []
     jsonifyPlayerData(playerList, playersJson)
 
-    # Increments the player as their choice doesn't make a change.
-    Action.updateCurrentPlayer(roomId, previousPlayer='player')
-
     # Updating the player data on client side
     emit('update player data', playersJson, room=roomId)
 
-    # Giving the new current player the choice.
+    # Increments the player as their choice doesn't make a change.
+    Action.updateCurrentPlayer(roomId, previousPlayer='player')
+
+    # Giving the current player the choice.
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-    emit('give player choice', currentPlayerId, room=roomId)
+    dealerPlayerId = dbUtils.getDealerId(roomId)
+    currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    while 'king' in currentPlayerCard:
+        if currentPlayerId == dealerPlayerId:
+            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+            endRound(roomId)
+            break
+        else:
+            Action.updateCurrentPlayer(roomId, previousPlayer='player')
+            currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+        emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('cut card')
 def cutCard():

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -160,7 +160,7 @@ def startGame():
     # Giving the current player the choice.
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     dealerPlayerId = dbUtils.getDealerId(roomId)
-    currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
     # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
@@ -172,7 +172,7 @@ def startGame():
         else:
             Action.updateCurrentPlayer(roomId, previousPlayer='player')
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+            currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
     # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
     # round is ended, the player is updated in later code, but the dealer must not get player choice and so
@@ -196,7 +196,7 @@ def stickCard():
         # Giving the current player the choice.
         currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
         dealerPlayerId = dbUtils.getDealerId(roomId)
-        currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+        currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
         # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
         while 'king' in currentPlayerCard:
@@ -208,7 +208,7 @@ def stickCard():
             else:
                 Action.updateCurrentPlayer(roomId, previousPlayer='player')
                 currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-                currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+                currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
         # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
         # round is ended, the player is updated in later code, but the dealer must not get player choice and so
@@ -238,7 +238,7 @@ def tradeCard():
     # Giving the current player the choice.
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     dealerPlayerId = dbUtils.getDealerId(roomId)
-    currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+    currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
     # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
@@ -250,7 +250,7 @@ def tradeCard():
         else:
             Action.updateCurrentPlayer(roomId, previousPlayer='player')
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+            currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
     # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
     # round is ended, the player is updated in later code, but the dealer must not get player choice and so

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -167,17 +167,6 @@ def startGame():
         # Destroy the reveal button since the player's king is revealed when they skip their go.
         emit('delete reveal button for player', currentPlayerId, room=roomId)
         if currentPlayerId == dealerPlayerId:
-            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-
-            # Gets the player list to extract the playerData and send a json.
-            playerList = dbUtils.getPlayerList(roomId)
-
-            # Extracts the playerData and to send a json.
-            playersJson = []
-            jsonifyPlayerData(playerList, playersJson)
-
-            # Revealing all the cards at the end of the round.
-            emit('reveal cards and trigger results', playersJson, room=roomId)
             endRound(roomId)
             break
         else:
@@ -199,16 +188,6 @@ def stickCard():
     dealerId = dbUtils.getDealerId(roomId)
 
     if currentPlayerId == dealerId:
-        # Gets the player list to extract the playerData and send a json.
-        playerList = dbUtils.getPlayerList(roomId)
-
-        # Extracts the playerData and to send a json.
-        playersJson = []
-        jsonifyPlayerData(playerList, playersJson)
-
-        # Dealer just stuck so end round.
-        emit('reveal cards and trigger results', playersJson, room=roomId)
-
         endRound(roomId)
     else:
         # increments the player as their choice doesn't make a change.
@@ -224,17 +203,6 @@ def stickCard():
             # Destroy the reveal button since the player's king is revealed when they skip their go.
             emit('delete reveal button for player', currentPlayerId, room=roomId)
             if currentPlayerId == dealerPlayerId:
-                currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-
-                # Gets the player list to extract the playerData and send a json.
-                playerList = dbUtils.getPlayerList(roomId)
-
-                # Extracts the playerData and to send a json.
-                playersJson = []
-                jsonifyPlayerData(playerList, playersJson)
-
-                # Revealing all the cards at the end of the round.
-                emit('reveal cards and trigger results', playersJson, room=roomId)
                 endRound(roomId)
                 break
             else:
@@ -256,11 +224,9 @@ def tradeCard():
     # Trades cards with the next person in the game.
     Action.tradeCards(roomId)
 
-    # Gets the player list to extract the playerData and send a json.
-    playerList = dbUtils.getPlayerList(roomId)
-
-    # Extracts the playerData and to send a json.
+    # Prepare player data to emit it to all players.
     playersJson = []
+    playerList = dbUtils.getPlayerList(roomId)
     jsonifyPlayerData(playerList, playersJson)
 
     # Updating the player data on client side
@@ -279,17 +245,6 @@ def tradeCard():
         # Destroy the reveal button since the player's king is revealed when they skip their go.
         emit('delete reveal button for player', currentPlayerId, room=roomId)
         if currentPlayerId == dealerPlayerId:
-            currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-
-            # Gets the player list to extract the playerData and send a json.
-            playerList = dbUtils.getPlayerList(roomId)
-
-            # Extracts the playerData and to send a json.
-            playersJson = []
-            jsonifyPlayerData(playerList, playersJson)
-
-            # Revealing all the cards at the end of the round.
-            emit('reveal cards and trigger results', playersJson, room=roomId)
             endRound(roomId)
             break
         else:
@@ -314,18 +269,13 @@ def cutCard():
     # Increments the player too match stick card functionality to line up ending the round regardless of choice.
     Action.updateCurrentPlayer(roomId, previousPlayer='player')
 
-    # Gets the player list to extract the playerData and send a json.
-    playerList = dbUtils.getPlayerList(roomId)
-
-    # Extracts the playerData and to send a json.
+    # Prepare player data to emit it to all players.
     playersJson = []
+    playerList = dbUtils.getPlayerList(roomId)
     jsonifyPlayerData(playerList, playersJson)
 
     # Updating the player data on client side
     emit('update player data', playersJson, room=roomId)
-
-    # Dealer just stuck so end round.
-    emit('reveal cards and trigger results', playersJson, room=roomId)
 
     endRound(roomId)
 
@@ -334,11 +284,9 @@ def revealKing():
     roomId = session.get('roomId')
     playerId = session.get('playerId')
 
-    # Gets the player list to extract the playerData and send a json.
-    playerList = dbUtils.getPlayerList(roomId)
-
-    # Extracts the playerData and to send a json.
+    # Prepare player data to emit it to all players.
     playersJson = []
+    playerList = dbUtils.getPlayerList(roomId)
     jsonifyPlayerData(playerList, playersJson)
 
     emit('reveal king of playerId', (playersJson, playerId), room=roomId)
@@ -364,6 +312,14 @@ def jsonifyPlayerData(playerList, playersJson):
         playersJson.append(jsonData)
 
 def endRound(roomId):
+    # Prepare player data to emit it to all players.
+    playersJson = []
+    playerList = dbUtils.getPlayerList(roomId)
+    jsonifyPlayerData(playerList, playersJson)
+
+    # Revealing all the cards at the end of the round.
+    emit('reveal cards and trigger results', playersJson, room=roomId)
+
     # Calculate the winner and adjust lives accordingly.
     Action.calculateRoundWinner(roomId)
 

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -168,28 +168,25 @@ def stickCard():
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     dealerId = dbUtils.getDealerId(roomId)
 
-    # increments the player as their choice doesn't make a change.
-    Action.updateCurrentPlayer(roomId, previousPlayer='player')
-
-    # Gets the player list to extract the playerData and send a json.
-    playerList = dbUtils.getPlayerList(roomId)
-
-    # Extracts the playerData and to send a json.
-    playersJson = []
-    jsonifyPlayerData(playerList, playersJson)
-
-    # Updating the player data on client side
-    emit('update player data', playersJson, room=roomId)
-
-    updatedCurrentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     if currentPlayerId == dealerId:
+        # Gets the player list to extract the playerData and send a json.
+        playerList = dbUtils.getPlayerList(roomId)
+
+        # Extracts the playerData and to send a json.
+        playersJson = []
+        jsonifyPlayerData(playerList, playersJson)
+
         # Dealer just stuck so end round.
         emit('reveal cards and trigger results', playersJson, room=roomId)
 
         endRound(roomId)
     else:
+        # increments the player as their choice doesn't make a change.
+        Action.updateCurrentPlayer(roomId, previousPlayer='player')
+        currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
+
         # Giving the new current player the choice.
-        emit('give player choice', updatedCurrentPlayerId, room=roomId)
+        emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('trade card')
 def tradeCard():

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -161,6 +161,8 @@ def startGame():
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     dealerPlayerId = dbUtils.getDealerId(roomId)
     currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+    # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
         if currentPlayerId == dealerPlayerId:
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
@@ -170,7 +172,11 @@ def startGame():
             Action.updateCurrentPlayer(roomId, previousPlayer='player')
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-    if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+
+    # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
+    # round is ended, the player is updated in later code, but the dealer must not get player choice and so
+    # the if statement is necessary.
+    if 'king' not in currentPlayerCard:
         emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('stick card')
@@ -195,15 +201,13 @@ def stickCard():
     else:
         # increments the player as their choice doesn't make a change.
         Action.updateCurrentPlayer(roomId, previousPlayer='player')
-        # currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
-        #
-        # # Giving the new current player the choice.
-        # emit('give player choice', currentPlayerId, room=roomId)
 
         # Giving the current player the choice.
         currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
         dealerPlayerId = dbUtils.getDealerId(roomId)
         currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+        # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
         while 'king' in currentPlayerCard:
             if currentPlayerId == dealerPlayerId:
                 currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
@@ -213,7 +217,11 @@ def stickCard():
                 Action.updateCurrentPlayer(roomId, previousPlayer='player')
                 currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
                 currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-        if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+
+        # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
+        # round is ended, the player is updated in later code, but the dealer must not get player choice and so
+        # the if statement is necessary.
+        if 'king' not in currentPlayerCard:
             emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('trade card')
@@ -241,6 +249,8 @@ def tradeCard():
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
     dealerPlayerId = dbUtils.getDealerId(roomId)
     currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+    # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
         if currentPlayerId == dealerPlayerId:
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
@@ -250,7 +260,11 @@ def tradeCard():
             Action.updateCurrentPlayer(roomId, previousPlayer='player')
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
-    if currentPlayerId != dealerPlayerId or 'king' not in currentPlayerCard:
+
+    # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
+    # round is ended, the player is updated in later code, but the dealer must not get player choice and so
+    # the if statement is necessary.
+    if 'king' not in currentPlayerCard:
         emit('give player choice', currentPlayerId, room=roomId)
 
 @socketio.on('cut card')

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -315,7 +315,7 @@ def endRound(roomId):
     jsonifyPlayerData(playerList, playersJson)
 
     # Revealing all the cards at the end of the round.
-    emit('reveal cards and trigger results', playersJson, room=roomId)
+    emit('reveal all cards', playersJson, room=roomId)
 
     # Calculate the winner and adjust lives accordingly.
     Action.calculateRoundWinner(roomId)

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -129,7 +129,7 @@ def startGame():
         # Setting the lives of the players and their out of game statuses.
         playerList = dbUtils.getPlayerList(roomId)
         for i in range(len(playerList)):
-            playerList[i].lives = 5
+            playerList[i].lives = 3
             playerList[i].outOfGame = False
         db.session.commit()
 

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -174,9 +174,8 @@ def startGame():
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
             currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
-    # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
-    # round is ended, the player is updated in later code, but the dealer must not get player choice and so
-    # the if statement is necessary.
+    # If the player has a king, they would be skipped regardless, but if the dealer has a king when the round ends
+    # the current player is on round end and the dealer mustn't get a choice.
     if 'king' not in currentPlayerCard:
         emit('give player choice', currentPlayerId, room=roomId)
 
@@ -210,9 +209,8 @@ def stickCard():
                 currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
                 currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
-        # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
-        # round is ended, the player is updated in later code, but the dealer must not get player choice and so
-        # the if statement is necessary.
+        # If the player has a king, they would be skipped regardless, but if the dealer has a king when the round ends
+        # the current player is on round end and the dealer mustn't get a choice.
         if 'king' not in currentPlayerCard:
             emit('give player choice', currentPlayerId, room=roomId)
 
@@ -252,9 +250,8 @@ def tradeCard():
             currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
             currentPlayerCard = dbUtils.getPlayerCard(roomId, currentPlayerId)
 
-    # If the player has a king, they would be skipped regardless, but if the dealer had a king, then the
-    # round is ended, the player is updated in later code, but the dealer must not get player choice and so
-    # the if statement is necessary.
+    # If the player has a king, they would be skipped regardless, but if the dealer has a king when the round ends
+    # the current player is on round end and the dealer mustn't get a choice.
     if 'king' not in currentPlayerCard:
         emit('give player choice', currentPlayerId, room=roomId)
 

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -145,9 +145,6 @@ def startGame():
     # Dealing the cards to the players.
     Action.dealCards(roomId)
 
-    # Updating the current player as it cannot be the dealer
-    Action.updateCurrentPlayer(roomId, previousPlayer='dealer')
-
     # Extracts the playerData and to send a json.
     playerList = dbUtils.getPlayerList(roomId)
     playersJson = []
@@ -156,6 +153,9 @@ def startGame():
     # Updating the player data on client side.
     emit('update player data', playersJson, room = roomId)
     emit('update player lives', playersJson, room = roomId)
+
+    # Updating the current player as it cannot be the dealer
+    Action.updateCurrentPlayer(roomId, previousPlayer='dealer')
 
     # Giving the current player the choice.
     currentPlayerId = dbUtils.getCurrentPlayerId(roomId)
@@ -196,15 +196,15 @@ def tradeCard():
     # Trades cards with the next person in the game.
     Action.tradeCards(roomId)
 
-    # Increments the player as their choice doesn't make a change.
-    Action.updateCurrentPlayer(roomId, previousPlayer='player')
-
     # Gets the player list to extract the playerData and send a json.
     playerList = dbUtils.getPlayerList(roomId)
 
     # Extracts the playerData and to send a json.
     playersJson = []
     jsonifyPlayerData(playerList, playersJson)
+
+    # Increments the player as their choice doesn't make a change.
+    Action.updateCurrentPlayer(roomId, previousPlayer='player')
 
     # Updating the player data on client side
     emit('update player data', playersJson, room=roomId)

--- a/application/controllers/games/chase_the_ace_gameplay.py
+++ b/application/controllers/games/chase_the_ace_gameplay.py
@@ -164,8 +164,20 @@ def startGame():
 
     # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
+        # Destroy the reveal button since the player's king is revealed when they skip their go.
+        emit('delete reveal button for player', currentPlayerId, room=roomId)
         if currentPlayerId == dealerPlayerId:
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+            # Gets the player list to extract the playerData and send a json.
+            playerList = dbUtils.getPlayerList(roomId)
+
+            # Extracts the playerData and to send a json.
+            playersJson = []
+            jsonifyPlayerData(playerList, playersJson)
+
+            # Revealing all the cards at the end of the round.
+            emit('reveal cards and trigger results', playersJson, room=roomId)
             endRound(roomId)
             break
         else:
@@ -209,8 +221,20 @@ def stickCard():
 
         # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
         while 'king' in currentPlayerCard:
+            # Destroy the reveal button since the player's king is revealed when they skip their go.
+            emit('delete reveal button for player', currentPlayerId, room=roomId)
             if currentPlayerId == dealerPlayerId:
                 currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+                # Gets the player list to extract the playerData and send a json.
+                playerList = dbUtils.getPlayerList(roomId)
+
+                # Extracts the playerData and to send a json.
+                playersJson = []
+                jsonifyPlayerData(playerList, playersJson)
+
+                # Revealing all the cards at the end of the round.
+                emit('reveal cards and trigger results', playersJson, room=roomId)
                 endRound(roomId)
                 break
             else:
@@ -252,8 +276,20 @@ def tradeCard():
 
     # While they have a king, they are either skipped or the dealer ends the round (if the dealer has the king).
     while 'king' in currentPlayerCard:
+        # Destroy the reveal button since the player's king is revealed when they skip their go.
+        emit('delete reveal button for player', currentPlayerId, room=roomId)
         if currentPlayerId == dealerPlayerId:
             currentPlayerCard = dbUtils.getSpecificPlayer(roomId, currentPlayerId).card
+
+            # Gets the player list to extract the playerData and send a json.
+            playerList = dbUtils.getPlayerList(roomId)
+
+            # Extracts the playerData and to send a json.
+            playersJson = []
+            jsonifyPlayerData(playerList, playersJson)
+
+            # Revealing all the cards at the end of the round.
+            emit('reveal cards and trigger results', playersJson, room=roomId)
             endRound(roomId)
             break
         else:
@@ -292,6 +328,20 @@ def cutCard():
     emit('reveal cards and trigger results', playersJson, room=roomId)
 
     endRound(roomId)
+
+@socketio.on('reveal king')
+def revealKing():
+    roomId = session.get('roomId')
+    playerId = session.get('playerId')
+
+    # Gets the player list to extract the playerData and send a json.
+    playerList = dbUtils.getPlayerList(roomId)
+
+    # Extracts the playerData and to send a json.
+    playersJson = []
+    jsonifyPlayerData(playerList, playersJson)
+
+    emit('reveal king of playerId', (playersJson, playerId), room=roomId)
 
 @socketio.on('delete all player cards')
 def deletePlayerCardsDisplay():

--- a/application/static/js/chase_the_ace/game/GamePage.js
+++ b/application/static/js/chase_the_ace/game/GamePage.js
@@ -10,7 +10,7 @@ class GamePage extends Phaser.Scene {
     playerNamesDisplays = new Array();
 
     // Player Lives
-    maxPlayerLives = 2;
+    maxPlayerLives = 5;
     playerLives;
     playerLivesDisplays = new Array();
 

--- a/application/static/js/chase_the_ace/game/GamePage.js
+++ b/application/static/js/chase_the_ace/game/GamePage.js
@@ -197,6 +197,11 @@ class GamePage extends Phaser.Scene {
                 }
             }
         })
+
+        socket.on('Next player has a king', function()
+        {
+            console.log('Next player has king')
+        })
     }
 
     displayStartButton()

--- a/application/static/js/chase_the_ace/game/GamePage.js
+++ b/application/static/js/chase_the_ace/game/GamePage.js
@@ -25,6 +25,8 @@ class GamePage extends Phaser.Scene {
     tradeButton;
     cutButton;
 
+    playerHasKing;
+
     // Phaser structure for constructor, preload and create methods.
     constructor()
     {
@@ -200,7 +202,7 @@ class GamePage extends Phaser.Scene {
 
         socket.on('Next player has a king', function()
         {
-            console.log('Next player has king')
+            gamePage.displayNextPlayerHasKing()
         })
     }
 
@@ -356,6 +358,23 @@ class GamePage extends Phaser.Scene {
     displayWin()
     {
         this.add.text(400, 80, 'Winner!')
+    }
+
+    displayNextPlayerHasKing()
+    {
+        this.playerHasKing = this.add.text(360, 80, 'Other player has a king!');
+        this.add.tween(
+        {
+            targets: this.playerHasKing,
+            ease: 'Sine.easeInOut',
+            duration: 1000,
+            delay: 1000,
+            alpha: 0,
+            onComplete: () =>
+            {
+                this.playerHasKing.destroy();
+            }
+        });
     }
 }
 

--- a/application/static/js/chase_the_ace/game/GamePage.js
+++ b/application/static/js/chase_the_ace/game/GamePage.js
@@ -176,7 +176,7 @@ class GamePage extends Phaser.Scene {
         })
 
         // Reveals all cards to everyone by the player names after the dealer's decision is made.
-        socket.on('reveal cards and trigger results', function(playerData)
+        socket.on('reveal all cards', function(playerData)
         {
             gamePage.displayAllPlayerCards(playerData)
         })

--- a/application/static/js/chase_the_ace/game/GamePage.js
+++ b/application/static/js/chase_the_ace/game/GamePage.js
@@ -10,7 +10,7 @@ class GamePage extends Phaser.Scene {
     playerNamesDisplays = new Array();
 
     // Player Lives
-    maxPlayerLives = 5;
+    maxPlayerLives = 3;
     playerLives;
     playerLivesDisplays = new Array();
 


### PR DESCRIPTION
* King trades stopped for happening and player is pinged that they tried to swap with a king. Text appears and fades that they tried to swap with a king.
* When the player with a king has a turn, their king is revealed to all.
* The player with a king (apart from dealers) are given a 'reveal king' button to reveal the king before their turn and the button deletes itself after clicking or after the player has a turn and their king is revealed regardless. Dealers don't get this button because they shouldn't know they have a king when it is face down, it is swappable while it is down and if the dealer cuts to a king, the round is over anyway and they don't need to reveal it when all cards are revealed.
